### PR TITLE
fix :  解决Androidx环境中调用原生升级无法弹框问题。

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -7,6 +7,11 @@
         android:usesCleartextTraffic="true"
         tools:targetApi="n">
 
+        <activity
+            android:name="com.tencent.bugly.beta.ui.BetaActivity"
+            android:configChanges="keyboardHidden|orientation|screenSize|locale"
+            android:theme="@android:style/Theme.Translucent" />
+
         <provider
             android:name="com.tencent.bugly.beta.utils.BuglyFileProvider"
             android:authorities="${applicationId}.fileProvider"

--- a/android/src/main/java/com/crazecoder/flutterbugly/FlutterBuglyPlugin.java
+++ b/android/src/main/java/com/crazecoder/flutterbugly/FlutterBuglyPlugin.java
@@ -84,16 +84,20 @@ public class FlutterBuglyPlugin implements FlutterPlugin, MethodCallHandler, Act
                 if (call.hasArgument("canShowApkInfo")) {
                     Beta.canShowApkInfo = call.argument("canShowApkInfo");
                 }
+                if (call.hasArgument("customUpgrade")) {
+                    boolean customUpgrade = call.argument("customUpgrade");
+                    /*在application中初始化时设置监听，监听策略的收取*/
+                    Beta.upgradeListener = customUpgrade ? new UpgradeListener() {
+                        @Override
+                        public void onUpgrade(int ret, UpgradeInfo strategy, boolean isManual, boolean isSilence) {
+                            Map<String, Object> data = new HashMap<>();
+                            data.put("upgradeInfo", JsonUtil.toJson(MapUtil.deepToMap(strategy)));
+                            channel.invokeMethod("onCheckUpgrade", data);
+                        }
+                    } : null;
+                }
                 Beta.canShowUpgradeActs.add(activity.getClass());
-                /*在application中初始化时设置监听，监听策略的收取*/
-                Beta.upgradeListener = new UpgradeListener() {
-                    @Override
-                    public void onUpgrade(int ret, UpgradeInfo strategy, boolean isManual, boolean isSilence) {
-                        Map<String, Object> data = new HashMap<>();
-                        data.put("upgradeInfo", JsonUtil.toJson(MapUtil.deepToMap(strategy)));
-                        channel.invokeMethod("onCheckUpgrade", data);
-                    }
-                };
+
                 String appId = call.argument("appId").toString();
                 Bugly.init(activity.getApplicationContext(), appId, BuildConfig.DEBUG);
                 if (call.hasArgument("channel")) {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -33,12 +33,14 @@ class _HomePageState extends State<HomePage> {
     FlutterBugly.init(
       androidAppId: "your app id",
       iOSAppId: "your app id",
+      customUpgrade: true,// 调用Android原生升级方式
     ).then((_result) {
       setState(() {
         _platformVersion = _result.message;
         print(_result.appId);
       });
     });
+    // 当配置 customUpgrade=true 时候，这里可以接收自定义升级
     FlutterBugly.onCheckUpgrade.listen((_upgradeInfo) {
         _showUpdateDialog(_upgradeInfo.newFeature, _upgradeInfo.apkUrl,
             _upgradeInfo.upgradeType == 2);

--- a/lib/src/flutter_bugly.dart
+++ b/lib/src/flutter_bugly.dart
@@ -32,6 +32,7 @@ class FlutterBugly {
     int initDelay = 0, //延迟初始化,单位秒
     int upgradeCheckPeriod = 0, //升级检查周期设置,单位秒
     int checkUpgradeCount = 1, //UpgradeInfo为null时，再次check的次数，经测试1为最佳
+    bool customUpgrade = true, // 是否自定义升级，这里默认true为了兼容老版本
   }) async {
     assert((Platform.isAndroid && androidAppId != null) ||
         (Platform.isIOS && iOSAppId != null));
@@ -48,6 +49,7 @@ class FlutterBugly {
       "canShowApkInfo": canShowApkInfo,
       "initDelay": initDelay,
       "upgradeCheckPeriod": upgradeCheckPeriod,
+      "customUpgrade": customUpgrade,
     };
     final String result = await _channel.invokeMethod('initBugly', map);
     Map resultMap = json.decode(result);


### PR DESCRIPTION
1，androidx项目使用bugly是可以支持support ui的调用的
2，添加自定义升级bool配置，可使用原生升级或者自定义升级。
请作者check。
